### PR TITLE
client: fix a bug in fcopyfile() and add tests for this bug

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -18694,7 +18694,9 @@ int Client::fcopyfile(const char *spath, const char *dpath, UserPerm& perms, mod
         if (r < 0) {
           ldout(cct, 10) << "fcopyfile: error reading copy data, r=" << r << dendl;
           goto out;
-        }
+        } else {
+	  len = r;
+	}
 
         r = write(dest, in_buf, len, off);
         if (r < 0) {
@@ -18703,8 +18705,15 @@ int Client::fcopyfile(const char *spath, const char *dpath, UserPerm& perms, mod
         }
         off = off + len;
 
-        if (off == size)
+        if (off == size) {
           break;
+	} else if (off > size) {
+	  ldout(cct, 0) << __FILE__ << ",  " << __func__ << "() at " << __LINE__
+		        << " internal error: \"off\" is greater than \"size\"; "
+			" off = " << off << " size = " << size << dendl;
+	  r = -1;
+	  goto out;
+	}
       }
     }
     out:

--- a/src/test/pybind/test_cephfs.py
+++ b/src/test/pybind/test_cephfs.py
@@ -940,3 +940,120 @@ def test_multi_target_command():
     if isinstance(mds_status, list): # if multi target command result
         for mds_sessions in session_map:
             assert(list(mds_sessions.keys())[0].startswith('mds.'))
+
+
+class TestFcopyfile:
+    '''
+    Tests for fcopyfile() method of CephFS Python bindings.
+    '''
+
+    PERMS = 0o755
+
+    def get_perm_bits_from_stat_mode(self, mode):
+        mode_oct = oct(mode)
+        # get only last three digits, rest is not relevant
+        perm_bits_str = mode_oct[-3:]
+        # convert from str to octal literal value
+        perms = int(perm_bits_str, 8)
+
+        return perms
+
+    def test_with_dir(self, testdir):
+        '''
+        Test that fcopyfile() create a new dir with expected mode.
+        '''
+        cephfs.mkdir('dir1', self.PERMS)
+
+        cephfs.fcopyfile('dir1', 'dir2', self.PERMS)
+
+        stat_result = cephfs.stat('dir2')
+        perms = self.get_perm_bits_from_stat_mode(stat_result.st_mode)
+        assert perms == self.PERMS
+
+    def test_with_symlink(self, testdir):
+        '''
+        Test that fcopyfile() creates a new symlink with same size, mode and
+        pointing to the same file.
+        '''
+        fd = cephfs.open(b'file1', 'w', self.PERMS)
+        SIZE = 1000
+        cephfs.write(fd, b'1' * SIZE, 0)
+        cephfs.close(fd)
+        cephfs.symlink('file1', 'slink1')
+
+        cephfs.fcopyfile('slink1', 'slink2', self.PERMS)
+        stat_result = cephfs.stat('slink2')
+        assert stat_result.st_size == SIZE
+
+        perms = self.get_perm_bits_from_stat_mode(stat_result.st_mode)
+        assert perms == self.PERMS
+
+        lstat_result1 = cephfs.stat('slink1')
+        lstat_result2 = cephfs.stat('slink2')
+        assert lstat_result1.st_size == lstat_result2.st_size
+
+        path1 = cephfs.readlink('slink1', 4096)
+        path2 = cephfs.readlink('slink2', 4096)
+        assert path1 == path2
+
+    def _write_file_and_test_fcopyfile(self, testdir, SIZE):
+        fd = cephfs.open(b'file1', 'w', self.PERMS)
+        cephfs.write(fd, b'1' * SIZE, 0)
+        cephfs.close(fd)
+
+        cephfs.fcopyfile('file1', 'file2', self.PERMS)
+
+        stat_result = cephfs.stat('file2')
+        assert stat_result.st_size == SIZE
+
+        perms = self.get_perm_bits_from_stat_mode(stat_result.st_mode)
+        assert perms == self.PERMS
+
+    def test_with_regfile_of_size_0_5MB(self, testdir):
+        '''
+        Test that fcopyfile() copies a 0.5 MB file and then verifies its size and
+        mode.
+        '''
+        self._write_file_and_test_fcopyfile(testdir, int(0.5 * 1000 * 1000))
+
+    def test_with_regfile_of_size_2MB(self, testdir):
+        '''
+        Test that fcopyfile() copies a 2 MB file and then verifies its size and
+        mode.
+        '''
+        self._write_file_and_test_fcopyfile(testdir, int(2 * 1000 * 1000))
+
+    def test_with_regfile_of_size_1MB(self, testdir):
+        '''
+        Test that fcopyfile() copies a 1 MB file and then verifies its size and
+        mode.
+        '''
+        self._write_file_and_test_fcopyfile(testdir, int(1000 * 1000))
+
+    def test_with_regfile_of_size_2MiB(self, testdir):
+        '''
+        Test that fcopyfile() copies a 2 MiB file and then verifies its size and
+        mode.
+        '''
+        self._write_file_and_test_fcopyfile(testdir, int(2 * 1024 * 1024))
+
+    def test_with_regfile_of_size_1_15MB(self, testdir):
+        '''
+        Test that fcopyfile() copies a 1.15 MB file and then verifies its size and
+        mode.
+        '''
+        self._write_file_and_test_fcopyfile(testdir, int(1.15 * 1000 * 1000))
+
+    def test_with_regfile_of_size_1_5MB(self, testdir):
+        '''
+        Test that fcopyfile() copies a 1.5 MB file and then verifies its size and
+        mode.
+        '''
+        self._write_file_and_test_fcopyfile(testdir, int(1.5 * 1000 * 1000))
+
+    def test_with_regfile_of_size_1GB(self, testdir):
+        '''
+        Test that fcopyfile() copies a 1 GB file and then verifies its size and
+        mode.
+        '''
+        self._write_file_and_test_fcopyfile(testdir, int(1 * 1000 * 1000 * 1000))


### PR DESCRIPTION
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>